### PR TITLE
Updating installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ For instructions on how to use the debugger visit the repository's [wiki](https:
 This debugger uses provenance information to reconstruct past-executions and allow users to explore them at their will. This tool will work with any program so long as it has provenance collected that follows [this format](https://github.com/End-to-end-provenance/ExtendedProvJson).
 
 ## Installation
-To install as a package run `pip setup.py install` from the repo directory. 
+To install as a package run `python setup.py install` from the repo directory. 
 
 If any dependency problems are found, the 
 Python requirements are in requirements.txt so run `pip install -r requirements.txt`. 


### PR DESCRIPTION
Hey @jwons 

cc: @Alison-Li

I was trying to get this working on my machine, it looks like an instruction might have a typo? I might just be bad with Python, though.

Running `pip setup.py install` resulted in `ERROR: unknown command "setup.py"`

This was resolved by running `python setup.py install`.